### PR TITLE
trlteRIL: Handle RIL_UNSOL_NITZ_TIME_RECEIVED

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/trlteRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/trlteRIL.java
@@ -58,39 +58,20 @@ public class trlteRIL extends RIL {
     }
 
     private void
-    handleNitzTimeReceived(Parcel p) {
-        String nitz = (String)responseString(p);
-        //if (RILJ_LOGD) unsljLogRet(RIL_UNSOL_NITZ_TIME_RECEIVED, nitz);
-
-        // has bonus long containing milliseconds since boot that the NITZ
-        // time was received
+    fixNitz(Parcel p) {
+        int dataPosition = p.dataPosition();
+        String nitz = p.readString();
         long nitzReceiveTime = p.readLong();
 
-        Object[] result = new Object[2];
-
-        String fixedNitz = nitz;
         String[] nitzParts = nitz.split(",");
-        if (nitzParts.length == 4) {
-            // 0=date, 1=time+zone, 2=dst, 3=garbage that confuses GsmServiceStateTracker (so remove it)
-            fixedNitz = nitzParts[0]+","+nitzParts[1]+","+nitzParts[2]+",";
-        }
-
-        result[0] = fixedNitz;
-        result[1] = Long.valueOf(nitzReceiveTime);
-
-        boolean ignoreNitz = SystemProperties.getBoolean(
-                        TelephonyProperties.PROPERTY_IGNORE_NITZ, false);
-
-        if (ignoreNitz) {
-            if (RILJ_LOGD) riljLog("ignoring UNSOL_NITZ_TIME_RECEIVED");
-        } else {
-            if (mNITZTimeRegistrant != null) {
-                mNITZTimeRegistrant
-                .notifyRegistrant(new AsyncResult (null, result, null));
-            } else {
-                // in case NITZ time registrant isnt registered yet
-                mLastNITZTimeInfo = result;
-            }
+        if (nitzParts.length >= 4) {
+            // 0=date, 1=time+zone, 2=dst, 3(+)=garbage that confuses ServiceStateTracker
+            nitz = nitzParts[0] + "," + nitzParts[1] + "," + nitzParts[2];
+            p.setDataPosition(dataPosition);
+            p.writeString(nitz);
+            p.writeLong(nitzReceiveTime);
+            // The string is shorter now, drop the extra bytes
+            p.setDataSize(p.dataPosition());
         }
     }
 
@@ -333,7 +314,9 @@ public class trlteRIL extends RIL {
                 newResponse = RIL_UNSOL_ON_SS;
                 break;
             case RIL_UNSOL_NITZ_TIME_RECEIVED:
-                handleNitzTimeReceived(p);
+                fixNitz(p);
+                p.setDataPosition(dataPosition);
+                super.processUnsolicited(p, type);
                 break;
         }
         if (newResponse != response) {

--- a/trlte.mk
+++ b/trlte.mk
@@ -102,8 +102,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/sound_trigger_platform_info.xml:system/etc/sound_trigger_platform_info_xml \
     $(LOCAL_PATH)/audio/jack_alsa_mixer.json:system/etc/jack_alsa_mixer.json \
     $(LOCAL_PATH)/audio/mixer_paths_i2s.xml:system/etc/mixer_paths_i2s.xml \
-    $(LOCAL_PATH)/audio/sound_trigger_mixer_paths.xml:system/etc/sound_trigger_mixer_paths.xml \
-    $(LOCAL_PATH)/audio/mixer_paths_eur.xml:install/bin/mixer_paths_eur.xml
+    $(LOCAL_PATH)/audio/sound_trigger_mixer_paths.xml:system/etc/sound_trigger_mixer_paths.xml
 
 # Bluetooth
 PRODUCT_PACKAGES += \
@@ -163,10 +162,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/idc/sec_e-pen.idc:system/usr/idc/sec_e-pen.idc \
     $(LOCAL_PATH)/idc/sec_touchscreen.idc:system/usr/idc/sec_touchscreen.idc
 
-# Keystore		
-PRODUCT_PACKAGES += \		
-    keystore.apq8084
- 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     sys.keymaster.loaded=true
 

--- a/trlte.mk
+++ b/trlte.mk
@@ -163,10 +163,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/idc/sec_e-pen.idc:system/usr/idc/sec_e-pen.idc \
     $(LOCAL_PATH)/idc/sec_touchscreen.idc:system/usr/idc/sec_touchscreen.idc
 
-# Keystore
-PRODUCT_PACKAGES += \
-    keystore.apq8084
-
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     sys.keymaster.loaded=true
 

--- a/trlte.mk
+++ b/trlte.mk
@@ -102,7 +102,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/sound_trigger_platform_info.xml:system/etc/sound_trigger_platform_info_xml \
     $(LOCAL_PATH)/audio/jack_alsa_mixer.json:system/etc/jack_alsa_mixer.json \
     $(LOCAL_PATH)/audio/mixer_paths_i2s.xml:system/etc/mixer_paths_i2s.xml \
-    $(LOCAL_PATH)/audio/sound_trigger_mixer_paths.xml:system/etc/sound_trigger_mixer_paths.xml
+    $(LOCAL_PATH)/audio/sound_trigger_mixer_paths.xml:system/etc/sound_trigger_mixer_paths.xml \
+    $(LOCAL_PATH)/audio/mixer_paths_eur.xml:install/bin/mixer_paths_eur.xml
 
 # Bluetooth
 PRODUCT_PACKAGES += \

--- a/trlte.mk
+++ b/trlte.mk
@@ -163,6 +163,10 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/idc/sec_e-pen.idc:system/usr/idc/sec_e-pen.idc \
     $(LOCAL_PATH)/idc/sec_touchscreen.idc:system/usr/idc/sec_touchscreen.idc
 
+# Keystore		
+PRODUCT_PACKAGES += \		
+    keystore.apq8084
+ 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     sys.keymaster.loaded=true
 


### PR DESCRIPTION
* This fixes auto time zone
* This is related to how it was handled in the
  old SamsungQualcommRIL class (deprecated) but
  the Parcel is fixed rather than handling it
  directly in the RIL subclass
* This is done so that after we handle it,
  it's handled by processUnsolicited in the
  super class, which handles this UNSOL
* The extra "garbage" that is sent in the
  RIL_UNSOL_NITZ_TIME_RECEIVED parcel seems
  to be country MCC code for whatever reason

Author: Gabriele M <moto.falcon.git@gmail.com>
source: https://review.lineageos.org/#/c/177357/