### PR TITLE
Revert "trlte-common: sepolicy: Clean-up policy for external sdcards"

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -56,6 +56,7 @@ TARGET_POWERHAL_SET_INTERACTIVE_EXT := $(DEVICE_PATH)/power/power_ext.c
 TARGET_RECOVERY_FSTAB := $(DEVICE_PATH)/rootdir/etc/fstab.qcom
 TARGET_USERIMAGES_USE_EXT4 := true
 TARGET_USERIMAGES_USE_F2FS := true
+LZMA_RAMDISK_TARGETS := recovery
 
 # SELinux
 include device/qcom/sepolicy/sepolicy.mk

--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -56,7 +56,6 @@ TARGET_POWERHAL_SET_INTERACTIVE_EXT := $(DEVICE_PATH)/power/power_ext.c
 TARGET_RECOVERY_FSTAB := $(DEVICE_PATH)/rootdir/etc/fstab.qcom
 TARGET_USERIMAGES_USE_EXT4 := true
 TARGET_USERIMAGES_USE_F2FS := true
-LZMA_RAMDISK_TARGETS := recovery
 
 # SELinux
 include device/qcom/sepolicy/sepolicy.mk

--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -1,6 +1,2 @@
 allow platform_app time_daemon:unix_stream_socket connectto;
 allow platform_app self:process ptrace;
-allow platform_app exfat:dir create_dir_perms;
-allow platform_app exfat:file create_file_perms;
-allow platform_app fuseblk:dir create_dir_perms;
-allow platform_app fuseblk:file create_file_perms;

--- a/sepolicy/priv_app.te
+++ b/sepolicy/priv_app.te
@@ -7,7 +7,3 @@ allow priv_app configfs:dir { read open search};
 allow priv_app efs_file:dir getattr;
 allow priv_app unlabeled:dir getattr;
 allow priv_app audio_data_file:dir search;
-allow priv_app exfat:dir create_dir_perms;
-allow priv_app exfat:file create_file_perms;
-allow priv_app fuseblk:dir create_dir_perms;
-allow priv_app fuseblk:file create_file_perms;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,7 +1,2 @@
 
 
-# These are safe for an untrusted_app -- they are the external SD card
-allow untrusted_app exfat:dir create_dir_perms;
-allow untrusted_app exfat:file create_file_perms;
-allow untrusted_app fuseblk:dir create_dir_perms;
-allow untrusted_app fuseblk:file create_file_perms;


### PR DESCRIPTION
Without reverting commit 5b0d29d neither tblte nor trlte will build.

* Yes, this looks horrendously wide-open, but this only applied for the
  complete sandbox that is external sdcard

Change-Id: Ibd1fe240eeed65f079e810a3da5157a4e64944f2 (reverted from commit 5b0d29def8c34686ea540fd315f33b6d7bda3498)

